### PR TITLE
fix: conflict when book appointments with two different doctors

### DIFF
--- a/apps/api/src/core/repository/working-time.repository.interface.ts
+++ b/apps/api/src/core/repository/working-time.repository.interface.ts
@@ -23,4 +23,10 @@ export interface IWorkingTimeRepository extends IGenericRepository<WorkingTimeEn
     currentDate: string,
     currentTime: string
   ): Promise<void>;
+
+  findWorkingTimeConflict(
+    patientId: string,
+    shiftId: string, 
+    date: string
+  ): Promise<WorkingTimeEntity | null>;
 }

--- a/apps/api/src/infrastructure/database/typeorm-nest/repository/appointment.repository.ts
+++ b/apps/api/src/infrastructure/database/typeorm-nest/repository/appointment.repository.ts
@@ -243,7 +243,7 @@ export class AppointmentRepository
       .andWhere('appointment.metadata->>\'doctorId\' = :doctorId', { doctorId })
       .andWhere('appointment.metadata->>\'date\' >= :startDate', { startDate })
       .andWhere('appointment.metadata->>\'date\' <= :endDate', { endDate })
-      .andWhere('appointment.status NOT IN (:...statuses)', { statuses: [AppointmentStatus.SCHEDULED, AppointmentStatus.CANCELLED] })
+      .andWhere('appointment.status != :status', { status: AppointmentStatus.CANCELLED })
 
     const rawResult = await queryBuilder.getRawOne();
     return rawResult ? parseInt(rawResult.count, 10) : 0;

--- a/apps/api/src/infrastructure/database/typeorm-nest/repository/consultation.repository.ts
+++ b/apps/api/src/infrastructure/database/typeorm-nest/repository/consultation.repository.ts
@@ -79,9 +79,9 @@ export class ConsultationRepository
     queryBuilder.leftJoinAndSelect('consultation.diagnosisResult', 'diagnosisResult')
                 .leftJoinAndSelect('diagnosisResult.diseases', 'resultDisease');
 
-    const sortField = 'updatedAt';
     const sortOrder = sortDirection ?? SortDirection.DESC;
-    queryBuilder.orderBy(`consultation.${sortField}`, sortOrder as 'ASC' | 'DESC');
+    queryBuilder.orderBy('workingTime.date', sortOrder as 'ASC' | 'DESC')
+      .addOrderBy('shift.from', sortOrder as 'ASC' | 'DESC');
 
     const [entities, total] = await queryBuilder.getManyAndCount();
 

--- a/apps/api/src/infrastructure/database/typeorm-nest/repository/doctor.repository.ts
+++ b/apps/api/src/infrastructure/database/typeorm-nest/repository/doctor.repository.ts
@@ -57,7 +57,7 @@ export class DoctorRepository
 
     if (request.keyword) {
       queryBuilder.andWhere(
-        `CONCAT(user.firstName, ' ', user.lastName) ILIKE :keyword`,
+        '(user.firstName ILIKE :keyword OR user.lastName ILIKE :keyword OR doctor.doctorCode ILIKE :keyword )',
         { keyword: `%${request.keyword}%` },
       );
     }

--- a/apps/api/src/infrastructure/database/typeorm-nest/repository/working-time.repository.ts
+++ b/apps/api/src/infrastructure/database/typeorm-nest/repository/working-time.repository.ts
@@ -7,7 +7,7 @@ import { plainToInstance } from "class-transformer";
 import { Repository } from "typeorm";
 
 import { ScheduleEntity , WorkingTimeEntity } from "@app/core/domain/entities";
-import { WorkingTimeStatus } from "@app/core/domain/enums";
+import { AppointmentStatus, WorkingTimeStatus } from "@app/core/domain/enums";
 
 import { WorkingTime } from "../entities";
 
@@ -103,5 +103,24 @@ export class WorkingTimeRepository
         )
       )`, { status: WorkingTimeStatus.AVAILABLE, currentDate, currentTime })
       .execute();
+  }
+
+  async findWorkingTimeConflict(
+    patientId: string,
+    shiftId: string,
+    date: string
+  ): Promise<WorkingTimeEntity | null> {
+    const queryBuilder = this.repository
+      .createQueryBuilder('workingTime')
+      .where('workingTime.shiftId = :shiftId', { shiftId })
+      .andWhere('workingTime.date = :date', { date })
+      .leftJoinAndSelect('workingTime.appointment', 'appointment')
+      .andWhere('appointment.patientId = :patientId', { patientId })
+      .andWhere('appointment.status = :status', { status: AppointmentStatus.SCHEDULED })
+      .leftJoinAndSelect('workingTime.doctor', 'doctor')
+      .leftJoinAndSelect('doctor.user', 'user')
+    
+    const entity = await queryBuilder.getOne();
+    return entity ? this._mapper.toDomain(entity) : null;
   }
 }

--- a/apps/api/src/modules/patient/infrastructures/patient.service.ts
+++ b/apps/api/src/modules/patient/infrastructures/patient.service.ts
@@ -5,7 +5,7 @@ import { REPOSITORY_INJECTION_TOKEN } from '@api/enums';
 import { plainToInstance } from 'class-transformer';
 import { Transactional } from 'typeorm-transactional';
 
-import { ExceptionHandler, NotFoundException } from '@app/core/exception';
+import { BadRequestException, ExceptionHandler, NotFoundException } from '@app/core/exception';
 
 import { CreatePatientResponseDto, PatientInfoDto, UpdatePatientDto } from '../dtos';
 import { IPatientService } from '../interfaces';
@@ -79,6 +79,12 @@ export class PatientService implements IPatientService {
     input: UpdatePatientDto):
   Promise<PatientInfoDto> {
     try {
+      const now = new Date(Date.now() + 7 * 60 * 60 * 1000); 
+      const currentDate = now.toISOString().split('T')[0];
+      if (input.dateOfBirth && input.dateOfBirth >= currentDate) {
+        throw new BadRequestException('Date of birth must be before current date');
+      }
+
       const existingPatient = await this.patientRepository.findOne({
         where: { userId },
         relations: ['user'],

--- a/apps/api/src/modules/shift/infrastructures/shift.service.ts
+++ b/apps/api/src/modules/shift/infrastructures/shift.service.ts
@@ -150,6 +150,13 @@ export class ShiftService implements IShiftService {
         throw new BadRequestException('Patient profile is not fully completed. Please complete your profile before booking a shift.');
       }
 
+      //Check if the patient has already booked an appointment with another doctor on the same day at the same time
+      const conflictAppointment = await this.workingTimeRepository.findWorkingTimeConflict(patientId, shiftId, date);
+      if (conflictAppointment) {
+        const doctorName = `${conflictAppointment.doctor?.user?.firstName ?? ''} ${conflictAppointment.doctor?.user?.lastName ?? ''}`;
+        throw new BadRequestException(`You have already booked an appointment with doctor ${doctorName} on ${date} at the same time.`);
+      }
+
       const workingTime = await this.workingTimeRepository.findOne({
         where: { 
           doctorId: doctorId,


### PR DESCRIPTION
Các lỗi đã được sửa: 
- Cập nhật lại hỗ trợ sort theo Cũ nhất trước/Mới nhất của hồ sơ khám bệnh của bệnh nhân 
- Validate lại Ngày sinh chỉ cho phép cập nhật ngày trước ngày hiện tại
- Xử lý lỗi 1 bệnh nhân có thể đặt cùng một khung giờ 2 bác sĩ
- Đã có thể tìm bác sĩ ở UI bệnh nhân theo mã bác sĩ
- Ở khung bệnh nhân tuần này được thống kê của bác sĩ có bổ sung thêm số lượng bệnh nhân đặt khám (Chưa khám)
